### PR TITLE
docs (do not merge yet): README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Horizon — Disaster Response and Emergency Management
+# Horizon: Disaster Response and Emergency Management
 
 **Status: Hackathon project** (built at HackUTA 6, Oct 12-13 2024, University of Texas at Arlington)
 
@@ -34,9 +34,9 @@ flowchart LR
 
 ## Layout
 
-- `Horizon/` — the React Native mobile app (`app/`, `components/`, `assets/`)
-- `backend/` — Express API (`routes/`, `models/`, `middleware/`, `utils/`)
-- `streamlit/` — Python admin dashboard
+- `Horizon/`: the React Native mobile app (`app/`, `components/`, `assets/`)
+- `backend/`: Express API (`routes/`, `models/`, `middleware/`, `utils/`)
+- `streamlit/`: Python admin dashboard
 
 ## Running it locally
 
@@ -59,4 +59,4 @@ This is hackathon-quality code: built in 24 hours, not maintained since, and not
 
 ## License
 
-No license file yet — treat as all-rights-reserved until one is added.
+No license file yet. Treat as all-rights-reserved until one is added.

--- a/README.md
+++ b/README.md
@@ -1,149 +1,62 @@
-# Horizon: Disaster Response and Emergency Management System
+# Horizon — Disaster Response and Emergency Management
 
-Horizon is a comprehensive mobile application designed to provide critical support during natural disasters and emergencies. By combining real-time disaster tracking, emergency service location, and user profile management, Horizon empowers both individuals seeking assistance and emergency service providers.
+**Status: Hackathon project** (built at HackUTA 6, Oct 12-13 2024, University of Texas at Arlington)
 
-## 🌊 Features
+Horizon is a mobile app for tracking nearby natural disasters and finding emergency services, paired with an admin dashboard for emergency-service providers. My team built it in the 24-hour HackUTA 6 hackathon.
 
-### For Individuals
-- **Real-time Disaster Tracking**: Monitor nearby natural disasters including wildfires, floods, earthquakes, and more.
-- **Emergency Services Locator**: Find nearby hospitals, shelters, and blood donation centers with distance information.
-- **SOS Emergency Call**: Quick access button to contact emergency services.
-- **Personal Health Profile**: Store critical health information for emergency responders.
-
-### For Emergency Service Providers
-- **Client Management Dashboard**: Track and manage emergency response clients.
-- **Alert Management System**: Receive and respond to emergency alerts in real-time.
-- **Service Coverage Visualization**: View service coverage and gaps on an interactive map.
-
-## 📱 Technologies
-
-### Frontend (Mobile App)
-- React Native
-- Expo
-- TypeScript
-- React Native Maps
-- Axios
-
-### Backend
-- Node.js
-- Express
-- MongoDB
-- JWT Authentication
-
-### Admin Dashboard
-- Streamlit (Python)
-
-### External APIs
-- NASA EONET (Earth Observatory Natural Event Tracker)
-- GDACS (Global Disaster Alert and Coordination System)
-- OpenStreetMap (via Overpass API)
-
-## 🚀 Getting Started
-
-### Prerequisites
-- Node.js (v14 or higher)
-- npm or yarn
-- Python 3.7+ (for admin dashboard)
-- MongoDB account
-
-### Installation
-
-#### Mobile App (Horizon)
-```bash
-# Navigate to the mobile app directory
-cd Horizon
-
-# Install dependencies
-npm install
-
-# Start the development server
-npm start
+```mermaid
+flowchart LR
+    Mobile[Horizon mobile app<br/>React Native + Expo] -->|REST| Backend[Node/Express API<br/>MongoDB + JWT]
+    Backend --> EONET[NASA EONET]
+    Backend --> GDACS[GDACS]
+    Backend --> OSM[OpenStreetMap / Overpass]
+    Admin[Streamlit admin dashboard] --> Backend
 ```
 
-#### Backend Server
+## Features
+
+**For individuals**
+- Real-time disaster tracking (wildfires, floods, earthquakes) via NASA EONET and GDACS
+- Nearby hospitals, shelters, and blood donation centers via OpenStreetMap/Overpass, with distance
+- SOS quick-call button
+- Personal health profile for emergency responders
+
+**For emergency service providers**
+- Client management dashboard
+- Alert management for incoming emergency alerts
+- Service coverage map
+
+## Stack
+
+- Mobile: React Native, Expo, TypeScript, React Native Maps, Axios
+- Backend: Node.js, Express, MongoDB, JWT auth
+- Admin dashboard: Streamlit (Python)
+
+## Layout
+
+- `Horizon/` — the React Native mobile app (`app/`, `components/`, `assets/`)
+- `backend/` — Express API (`routes/`, `models/`, `middleware/`, `utils/`)
+- `streamlit/` — Python admin dashboard
+
+## Running it locally
+
 ```bash
-# Navigate to the backend directory
-cd backend
+# mobile app
+cd Horizon && npm install && npm start
 
-# Install dependencies
-npm install
+# backend
+cd backend && npm install && node server.js
 
-# Start the server
-node server.js
+# admin dashboard
+cd streamlit && pip install -r requirements.txt && streamlit run app.py
 ```
 
-#### Admin Dashboard
-```bash
-# Navigate to the streamlit directory
-cd streamlit
+Backend needs a `.env` with `MONGO_URI` and `JWT_SECRET`. Point the mobile app at your backend by updating the API base URL in `Horizon/app/index.tsx`.
 
-# Install dependencies
-pip install -r requirements.txt
+## Status notes
 
-# Run the dashboard
-streamlit run app.py
-```
+This is hackathon-quality code: built in 24 hours, not maintained since, and not hardened for production (no rate limiting, minimal input validation). Treat it as a snapshot of what we shipped at the event rather than a live project.
 
-## 🔧 Configuration
+## License
 
-1. Create a `.env` file in the backend directory with the following variables:
-   ```
-   MONGO_URI=your_mongodb_connection_string
-   JWT_SECRET=your_jwt_secret
-   ```
-
-2. Update the API base URL in the mobile app:
-   - Open `Horizon/app/index.tsx`
-   - Update the API URLs to point to your backend server
-
-## 💡 How It Works
-
-1. **Disaster Data Collection**: The system aggregates data from multiple sources (EONET, GDACS) to provide comprehensive disaster information.
-
-2. **Location Services**: When a user opens the app, their location is determined (with permission) to find nearby emergency services and disasters.
-
-3. **Emergency Services Mapping**: The app identifies nearby hospitals, shelters, and blood donation centers using the OpenStreetMap API.
-
-4. **Alert System**: Emergency service providers can receive and manage alerts through the admin dashboard.
-
-## 📊 Project Structure
-
-- `/Horizon`: React Native mobile application
-  - `/app`: Main application entry points
-  - `/components`: Reusable UI components
-  - `/assets`: Images and fonts
-
-- `/backend`: Node.js/Express server
-  - `/routes`: API endpoint definitions
-  - `/models`: MongoDB data models
-  - `/middleware`: Authentication and other middleware
-  - `/utils`: Utility functions for disaster data processing
-
-- `/streamlit`: Python-based admin dashboard
-
-## 🔗 Contributing
-
-1. Fork the repository.
-2. Create your feature branch (`git checkout -b feature/amazing-feature`).
-3. Commit your changes (`git commit -m 'Add some amazing feature'`).
-4. Push to the branch (`git push origin feature/amazing-feature`).
-5. Open a Pull Request.
-
-## 📝 License
-
-This project was created for HackUTA 6 hackathon. All rights reserved.
-
-## 🙏 Acknowledgements
-
-- NASA EONET API for disaster data
-- GDACS for global disaster alerts
-- OpenStreetMap for location data
-- HackUTA 6 organizers and mentors
-
-## 🏆 Hackathon Participation
-
-Horizon was developed during the HackUTA 6 hackathon, held on October 12-13, 2024, at the University of Texas at Arlington. HackUTA is one of North Texas' largest hackathons, offering a 24-hour marathon for students to collaborate and innovate on software projects. ([hackuta.org](https://www.hackuta.org/))
-
-During the event, our team focused on addressing the challenges of disaster response and emergency management. Leveraging real-time data from NASA's EONET and GDACS, we aimed to create a tool that could assist both individuals in crisis and the emergency services that support them.
-
-Participating in HackUTA 6 provided us with invaluable experience, mentorship, and the opportunity to bring Horizon from concept to reality within a collaborative and competitive environment.
+No license file yet — treat as all-rights-reserved until one is added.


### PR DESCRIPTION
## Summary
- Rewrote README with an explicit "Hackathon project" status line and a small Mermaid diagram of the mobile/backend/admin-dashboard/external-API architecture.
- Trimmed emoji-heavy section headers and condensed the feature list; kept all factual claims (stack, external APIs, hackathon details) as they were, since they checked out against the code.
- Added an explicit status-notes section calling out that this is unmaintained hackathon code, not production-hardened.

## Why it matters
Sets accurate expectations (24-hour hackathon build, not a maintained product) for anyone browsing the profile.

## Docs changed
README.md only.

## Metadata changed
Description + topics via gh repo edit (react-native, expo, hackathon, express, mongodb).

## Validation performed
Confirmed directory layout (Horizon/, backend/, streamlit/) and stack claims (Express + MongoDB + JWT backend, React Native/Expo mobile, Streamlit dashboard) against the actual repo structure. Style-gate follow-up: grepped the README for em dashes (U+2014) and found 5 (lines 1, 37, 38, 39, 62), missed by the initial no-em-dash pass; replaced each with a colon, comma, or period+sentence split and re-grepped to confirm zero remain.

## Known uncertainties
Did not run the mobile app, backend, or dashboard (needs MongoDB, Expo, and mobile emulator/device setup unavailable here) — README accuracy is based on structure/dependency review, not execution.

## Needs owner confirmation
None outstanding — this repo is explicitly scoped as a Tier 2 metadata-and-README-only refresh.

## Security notes
This PR is docs-only and reproduces no secret values. Repository-hygiene findings (if any) were compiled for the owner in a private review report outside this PR.
